### PR TITLE
Remove calcByteLength

### DIFF
--- a/muschema/src/_number.ts
+++ b/muschema/src/_number.ts
@@ -32,6 +32,4 @@ export abstract class MuNumber implements MuSchema<number> {
 
     public abstract diff (b:number, t:number, stream:MuWriteStream) : boolean;
     public abstract patch (b:number, stream:MuReadStream) : number;
-
-    public abstract calcByteLength(x:MuNumber);
 }

--- a/muschema/src/array.ts
+++ b/muschema/src/array.ts
@@ -76,58 +76,20 @@ export class MuArray<ValueSchema extends MuSchema<any>>
         return result;
     }
 
-    // a word for length of array +
-    // bytes for trackers +
-    // bytes for data
-    public calcByteLength (x:_MuArrayType<ValueSchema>) : number {
-        const LENGTH_BYTES = 4;
-
-        const length = x.length;
-        const numTrackers = Math.ceil(length / 8);
-
-        let result = LENGTH_BYTES + numTrackers;
-
-        const valueSchema = this.muData;
-        switch (valueSchema.muType) {
-            case 'boolean':
-            case 'int8':
-            case 'uint8':
-                result += length;
-                break;
-            case 'int16':
-            case 'uint16':
-                result += length * 2;
-                break;
-            case 'float32':
-            case 'int32':
-            case 'uint32':
-                result += length * 4;
-                break;
-            case 'float64':
-                result += length * 8;
-                break;
-            default:
-                for (let i = 0; i < length; ++i) {
-                    result += valueSchema.calcByteLength!(x[i]);
-                }
-        }
-
-        return result;
-    }
-
     public diff (
         base:_MuArrayType<ValueSchema>,
         target:_MuArrayType<ValueSchema>,
         stream:MuWriteStream,
     ) : boolean {
-        stream.grow(this.calcByteLength(target));
-
         const prefixOffset = stream.offset;
         const targetLength = target.length;
+
+        const numTrackers = Math.ceil(targetLength / 8);
+        stream.grow(4 + numTrackers);
+
         stream.writeUint32(targetLength);
 
         let trackerOffset = stream.offset;
-        const numTrackers = Math.ceil(targetLength / 8);
         stream.offset = trackerOffset + numTrackers;
 
         let tracker = 0;

--- a/muschema/src/ascii.ts
+++ b/muschema/src/ascii.ts
@@ -18,8 +18,6 @@ export class MuASCIIString implements MuSchema<string> {
     public free () {}
     public clone (x:string) : string { return x; }
 
-    public calcByteLength (x:string) { return 4 + x.length; }
-
     public diff (base:string, target:string, out:MuWriteStream) : boolean {
         if (base !== target) {
             out.grow(4 + target.length);

--- a/muschema/src/boolean.ts
+++ b/muschema/src/boolean.ts
@@ -31,8 +31,4 @@ export class MuBoolean implements MuSchema<boolean> {
     public patch (a:boolean, stream:MuReadStream) {
         return !!stream.readUint8();
     }
-
-    public calcByteLength (b:MuBoolean) {
-        return 1;
-    }
 }

--- a/muschema/src/constants.ts
+++ b/muschema/src/constants.ts
@@ -1,15 +1,16 @@
-export const muPrimitiveTypes = [
-    'boolean',
-    'float32',
-    'float64',
-    'int8',
-    'int16',
-    'int32',
-    'string',
-    'uint8',
-    'uint16',
-    'uint32',
-];
+export const muPrimitiveSize = {
+    'boolean': 1,
+    'uint8': 1,
+    'uint16': 2,
+    'uint32': 4,
+    'int8': 1,
+    'int16': 2,
+    'int32': 4,
+    'float32': 4,
+    'float64': 8,
+};
+
+export const muPrimitiveTypes = Object.keys(muPrimitiveSize);
 
 export const muNonPrimitiveTypes = [
     'array',
@@ -50,6 +51,7 @@ export const muType2WriteMethod = {
     uint16: 'writeUint16',
     uint32: 'writeUint32',
 };
+
 export const muType2ReadMethod = {
     boolean: 'readUint8',
     float32: 'readFloat32',

--- a/muschema/src/fixed-ascii.ts
+++ b/muschema/src/fixed-ascii.ts
@@ -40,10 +40,6 @@ export class MuFixedASCIIString implements MuSchema<string> {
     public free () : void {}
     public clone (x:string) : string { return x; }
 
-    public calcByteLength (x:string) : number {
-        return this.length;
-    }
-
     public diff (base:string, target:string, out:MuWriteStream) : boolean {
         const length = this.length;
         if (base.length !== length) {

--- a/muschema/src/float32.ts
+++ b/muschema/src/float32.ts
@@ -18,8 +18,4 @@ export class MuFloat32 extends MuNumber {
     public patch (base:number, stream:MuReadStream) {
         return stream.readFloat32();
     }
-
-    public calcByteLength (x:MuFloat32) {
-        return 4;
-    }
 }

--- a/muschema/src/float64.ts
+++ b/muschema/src/float64.ts
@@ -18,8 +18,4 @@ export class MuFloat64 extends MuNumber {
     public patch (base:number, stream:MuReadStream) {
         return stream.readFloat64();
     }
-
-    public calcByteLength (x:MuFloat64) {
-        return 8;
-    }
 }

--- a/muschema/src/int16.ts
+++ b/muschema/src/int16.ts
@@ -18,8 +18,4 @@ export class MuInt16 extends MuNumber {
     public patch (base:number, stream:MuReadStream) {
         return stream.readInt16();
     }
-
-    public calcByteLength (x:MuInt16) {
-        return 2;
-    }
 }

--- a/muschema/src/int32.ts
+++ b/muschema/src/int32.ts
@@ -18,8 +18,4 @@ export class MuInt32 extends MuNumber {
     public patch (base:number, stream:MuReadStream) {
         return stream.readInt32();
     }
-
-    public calcByteLength (x:MuInt32) {
-        return 4;
-    }
 }

--- a/muschema/src/int8.ts
+++ b/muschema/src/int8.ts
@@ -18,8 +18,4 @@ export class MuInt8 extends MuNumber {
     public patch (base:number, stream:MuReadStream) {
         return stream.readInt8();
     }
-
-    public calcByteLength (x:MuInt8) {
-        return 1;
-    }
 }

--- a/muschema/src/schema.ts
+++ b/muschema/src/schema.ts
@@ -27,6 +27,4 @@ export interface MuSchema<Value> {
 
     /** Apply a patch to an object */
     patch (base:Value, inp:MuReadStream) : Value;
-
-    calcByteLength (x:any) : number;
 }

--- a/muschema/src/sorted.ts
+++ b/muschema/src/sorted.ts
@@ -295,8 +295,4 @@ export class MuSortedArray<ValueSchema extends MuSchema<any>>
         }
         return result;
     }
-
-    public calcByteLength () : number {
-        return 128;
-    }
 }

--- a/muschema/src/string.ts
+++ b/muschema/src/string.ts
@@ -31,8 +31,4 @@ export class MuString implements MuSchema<string> {
     public patch (base:string, stream:MuReadStream) {
         return stream.readString();
     }
-
-    public calcByteLength (str:string) {
-        return 4 + str.length * 4;
-    }
 }

--- a/muschema/src/test/array.ts
+++ b/muschema/src/test/array.ts
@@ -127,52 +127,6 @@ test('array (nested) - clone()', (t) => {
     t.end();
 });
 
-test('array - calcByteLength()', (t) => {
-    const muType2BytesPerElement = {
-        boolean: 1,
-        float32: 4,
-        float64: 8,
-        int8: 1,
-        int16: 2,
-        int32: 4,
-        uint8: 1,
-        uint16: 2,
-        uint32: 4,
-    };
-
-    for (const muType of muPrimitiveTypes) {
-        const valueSchema = muPrimitiveSchema(muType);
-        const arraySchema = new MuArray(valueSchema);
-
-        const arr = flatArrayOf(muType);
-
-        const LENGTH_BYTES = 4;
-
-        const length = arr.length;
-        const BITS_PER_BYTE = 8;
-        const trackerBytes = Math.ceil(length / BITS_PER_BYTE);
-
-        let elementBytes = length * muType2BytesPerElement[muType];
-
-        if (muType === 'string') {
-            const STR_LENGTH_BYTES = 4;
-            const BYTES_PER_CHAR = 4;
-            const sumStrsLength = arr.reduce(
-                (acc, str) => acc + str.length,
-                0,
-            );
-            elementBytes = length * STR_LENGTH_BYTES + sumStrsLength * BYTES_PER_CHAR;
-        }
-
-        t.equals(
-            arraySchema.calcByteLength(arr),
-            LENGTH_BYTES + trackerBytes + elementBytes,
-        );
-    }
-
-    t.end();
-});
-
 test('array (flat) - diff() & patch()', (t) => {
     for (const muType of muPrimitiveTypes) {
         const valueSchema = muPrimitiveSchema(muType);

--- a/muschema/src/test/dictionary.ts
+++ b/muschema/src/test/dictionary.ts
@@ -103,63 +103,6 @@ test('dictionary (nested) - clone()', (t) => {
     t.end();
 });
 
-test('dictionary - calcByteLength()', (t) => {
-    function sumStrsLength (strs:string[]) {
-        return strs.reduce(
-            (acc, str) => acc + str.length,
-            0,
-        );
-    }
-
-    function calcStrsByteLength (strs:string[]) {
-        let result = 0;
-
-        const STR_LENGTH_BYTES = 4;
-        const BYTES_PER_CHAR = 4;
-
-        result += strs.length * STR_LENGTH_BYTES;
-        result += sumStrsLength(strs) * BYTES_PER_CHAR;
-
-        return result;
-    }
-
-    const muType2numBytes = {
-        boolean: 1,
-        float32: 4,
-        float64: 8,
-        int8: 1,
-        int16: 2,
-        int32: 4,
-        uint8: 1,
-        uint16: 2,
-        uint32: 4,
-    };
-
-    for (const muType of muPrimitiveTypes) {
-        const valueSchema = muPrimitiveSchema(muType);
-        const dictSchema = new MuDictionary(valueSchema);
-
-        const dict = flatDictOf(muType, randomShortStr);
-
-        const COUNTER_BYTES = 8;
-
-        const props = Object.keys(dict);
-        const propsByteLength = calcStrsByteLength(props);
-        const numProps = props.length;
-
-        let valuesByteLength = numProps * muType2numBytes[muType];
-
-        if (muType === 'string') {
-            const values = props.map((k) => dict[k]);
-            valuesByteLength = calcStrsByteLength(values);
-        }
-
-        t.equals(dictSchema.calcByteLength(dict), COUNTER_BYTES + propsByteLength + valuesByteLength);
-    }
-
-    t.end();
-});
-
 test('dictionary (flat) - diff() & patch()', (t) => {
     for (const muType of muPrimitiveTypes) {
         const valueSchema = muPrimitiveSchema(muType);

--- a/muschema/src/test/numbers.ts
+++ b/muschema/src/test/numbers.ts
@@ -1,5 +1,5 @@
 import test = require('tape');
-import CONSTANTS = require('../constants');
+import { Constants } from '../constants';
 
 import {
     MuInt8,
@@ -39,8 +39,8 @@ test('alloc() & clone()', (t) => {
         t.equals(n.clone(0), 0);
 
         const muType = n.muType;
-        const min = CONSTANTS[muType].MIN;
-        const max = CONSTANTS[muType].MAX;
+        const min = Constants[muType].MIN;
+        const max = Constants[muType].MAX;
 
         n = new Type(min);
 
@@ -62,8 +62,8 @@ test('alloc() & clone()', (t) => {
             t.equals(n.clone(-1), -1);
         }
 
-        if (CONSTANTS[muType]['EPSILON']) {
-            const epsilon = CONSTANTS[muType]['EPSILON'];
+        if (Constants[muType]['EPSILON']) {
+            const epsilon = Constants[muType]['EPSILON'];
 
             n = new Type(-epsilon);
 
@@ -93,10 +93,6 @@ test('diff() & patch()', (t) => {
         t.equals(n.diff(smallNum, 0, ws), false);
         t.equals(n.diff(0, 1 - smallNum, ws), false);
         t.equals(n.diff(1 - smallNum, 0, ws), false);
-
-        const rs = new MuReadStream(ws.buffer.uint8);
-
-        t.equals(n.patch(123, rs), 123, 'no content to be read, return the base value');
     });
 
     TYPES.forEach((Type) => {
@@ -104,8 +100,8 @@ test('diff() & patch()', (t) => {
         const ws = new MuWriteStream(2);
 
         const muType = n.muType;
-        const min = CONSTANTS[muType].MIN;
-        const max = CONSTANTS[muType].MAX;
+        const min = Constants[muType].MIN;
+        const max = Constants[muType].MAX;
 
         t.equals(n.diff(1, min, ws), true);
         t.equals(n.diff(1, 0, ws), true);
@@ -116,7 +112,6 @@ test('diff() & patch()', (t) => {
         t.equals(n.patch(123, rs), min);
         t.equals(n.patch(123, rs), 0);
         t.equals(n.patch(123, rs), max);
-        t.equals(n.patch(123, rs), 123, 'running out of content, return the base value');
     });
 
     FLOATS.forEach((Type) => {
@@ -124,7 +119,7 @@ test('diff() & patch()', (t) => {
         const ws = new MuWriteStream(2);
 
         const muType = n.muType;
-        const epsilon = CONSTANTS[muType]['EPSILON'];
+        const epsilon = Constants[muType]['EPSILON'];
 
         t.equals(n.diff(1.0, -epsilon, ws), true);
         t.equals(n.diff(1.0, epsilon, ws), true);

--- a/muschema/src/test/string.ts
+++ b/muschema/src/test/string.ts
@@ -39,10 +39,9 @@ test('string', (t) => {
     t.equals(s.diff(longStr, longStr, ws), false);
     t.equals(s.diff(longStr, longStr.substring(0, longStr.length - 1), ws), true);
 
-    const rs = new MuReadStream(ws.buffer.uint8);
+    const rs = new MuReadStream(ws.bytes());
 
     t.equals(s.patch(longStr, rs), longStr.substring(0, longStr.length - 1));
-    t.equals(s.patch(longStr, rs), longStr, 'running out of content, return the base value');
 
     t.end();
 });

--- a/muschema/src/test/struct.ts
+++ b/muschema/src/test/struct.ts
@@ -50,32 +50,6 @@ test('struct - identity', (t) => {
     t.end();
 });
 
-test('struct - calcByteLength()', (t) => {
-    const structSchema = new MuStruct({
-        v: new MuFloat64(0.233),
-        s: new MuString('foo'),
-        b: new MuBoolean(),
-    });
-
-    const struct = {
-        v: 0.233,
-        s: 'foo',
-        b: false,
-    };
-
-    const numProps = Object.keys(struct).length;
-    const BITS_PER_BYTE = 8;
-    const trackerBytes = Math.ceil(numProps / BITS_PER_BYTE);
-    const dataBytes = 8 + 4 + 3 * 4 + 1;
-
-    t.equals(
-        structSchema.calcByteLength(struct),
-        trackerBytes + dataBytes,
-    );
-
-    t.end();
-});
-
 test('struct (flat) - diff() & patch()', (t) => {
     function structSpec () {
         const result = {};
@@ -156,9 +130,6 @@ test('struct (nested)', (t) => {
 
         const testPatchingPair = testPatchingPairFactory(t, structSchema);
         testPatchingPair(identity, struct);
-
-        // get byte length
-        t.equals(structSchema.calcByteLength(identity), depth + (depth - 1) * (4 + 6 * 4) + (4 + 4 * 4));
     }
 
     t.end();

--- a/muschema/src/test/union.ts
+++ b/muschema/src/test/union.ts
@@ -127,57 +127,6 @@ test('union (nested type-data pair) - clone()', (t) => {
     t.end();
 });
 
-test('union - calcByteLength()', (t) => {
-    // the spec keys can have arbitrary names
-    const schemaSpec = {
-        boolean: new MuBoolean(),
-        float32: new MuFloat32(),
-        float64: new MuFloat64(),
-        int8: new MuInt8(),
-        int16: new MuInt16(),
-        int32: new MuInt32(),
-        string: new MuString(),
-        uint8: new MuUint8(),
-        uint16: new MuUint16(),
-        uint32: new MuUint32(),
-    };
-    const unionSchema = new MuUnion(schemaSpec);
-
-    const muType2numBytes = {
-        boolean: 1,
-        float32: 4,
-        float64: 8,
-        int8: 1,
-        int16: 2,
-        int32: 4,
-        uint8: 1,
-        uint16: 2,
-        uint32: 4,
-    };
-
-    for (const muType of muPrimitiveTypes) {
-        const pair = randomPairOf(muType);
-
-        let dataBytes = muType2numBytes[muType];
-
-        const STR_LENGTH_BYTES = 4;
-        const BYTES_PER_CHAR = 4;
-        if (muType === 'string') {
-            dataBytes = STR_LENGTH_BYTES + pair.data.length * BYTES_PER_CHAR;
-        }
-
-        const TRACKER_BYTE = 1;
-        const TYPE_BYTE = 1;
-
-        t.equals(
-            unionSchema.calcByteLength(pair),
-            TRACKER_BYTE + TYPE_BYTE + dataBytes,
-        );
-    }
-
-    t.end();
-});
-
 test('union (flat type-data pair) - diff() & patch()', (t) => {
     // the spec keys can have arbitrary names
     const schemaSpec = {

--- a/muschema/src/test/vector.ts
+++ b/muschema/src/test/vector.ts
@@ -68,26 +68,6 @@ test('vector - clone()', (t) => {
     t.end();
 });
 
-test('vector - calcByteLength()', (t) => {
-    for (const muType of muNumTypes) {
-        const valueSchema = muNumSchema(muType);
-        const dimension = 100;
-        const vecSchema = new MuVector(valueSchema, dimension);
-
-        const vec = typedArrayOf(muType, dimension);
-
-        const dataBytes = dimension * vecSchema.identity.BYTES_PER_ELEMENT;
-        const trackerBytes = Math.ceil(dataBytes / 8);
-
-        t.equals(
-            vecSchema.calcByteLength(vec),
-            trackerBytes + dataBytes,
-        );
-    }
-
-    t.end();
-});
-
 test('vector - diff() & patch()', (t) => {
     for (const muType of muNumTypes) {
         const valueSchema = muNumSchema(muType);

--- a/muschema/src/trace.ts
+++ b/muschema/src/trace.ts
@@ -98,8 +98,4 @@ export class MuSchemaTrace<BaseSchema extends MuSchema<any>>
         this.allocCount++;
         return this.schema.patch(base, inp);
     }
-
-    public calcByteLength(x:BaseSchema['identity']) {
-        return this.schema.calcByteLength(x);
-    }
 }

--- a/muschema/src/uint16.ts
+++ b/muschema/src/uint16.ts
@@ -7,7 +7,7 @@ export class MuUint16 extends MuNumber {
     }
 
     public diff (base:number, target:number, stream:MuWriteStream) {
-        if (base !== target) {
+        if ((base & 0xffff) !== (target & 0xffff)) {
             stream.grow(2);
             stream.writeUint16(target);
             return true;
@@ -17,9 +17,5 @@ export class MuUint16 extends MuNumber {
 
     public patch (base:number, stream:MuReadStream) {
         return stream.readUint16();
-    }
-
-    public calcByteLength (x:MuUint16) {
-        return 2;
     }
 }

--- a/muschema/src/uint32.ts
+++ b/muschema/src/uint32.ts
@@ -7,7 +7,7 @@ export class MuUint32 extends MuNumber {
     }
 
     public diff (base:number, target:number, stream:MuWriteStream) {
-        if (base !== target) {
+        if ((base >>> 0) !== (target >>> 0)) {
             stream.grow(4);
             stream.writeUint32(target);
             return true;
@@ -17,9 +17,5 @@ export class MuUint32 extends MuNumber {
 
     public patch (base:number, stream:MuReadStream) {
         return stream.readUint32();
-    }
-
-    public calcByteLength (x:MuUint32) {
-        return 4;
     }
 }

--- a/muschema/src/uint8.ts
+++ b/muschema/src/uint8.ts
@@ -7,7 +7,7 @@ export class MuUint8 extends MuNumber {
     }
 
     public diff (base:number, target:number, stream:MuWriteStream) {
-        if (base !== target) {
+        if ((base & 0xff) !== (target & 0xff)) {
             stream.grow(1);
             stream.writeUint8(target);
             return true;
@@ -17,9 +17,5 @@ export class MuUint8 extends MuNumber {
 
     public patch (base:number, stream:MuReadStream) {
         return stream.readUint8();
-    }
-
-    public calcByteLength (x:MuUint8) {
-        return 1;
     }
 }

--- a/muschema/src/union.ts
+++ b/muschema/src/union.ts
@@ -66,20 +66,12 @@ export class MuUnion<SubTypes extends { [type:string]:MuSchema<any> }>
         };
     }
 
-    // one byte for tracker +
-    // one byte for the index of type +
-    // bytes for data
-    public calcByteLength (pair:_TypeDataPair<SubTypes>) : number {
-        const dataSchema = this.muData[pair.type];
-        return 2 + dataSchema.calcByteLength!(pair.data);
-    }
-
     public diff (
         base:_TypeDataPair<SubTypes>,
         target:_TypeDataPair<SubTypes>,
         stream:MuWriteStream,
     ) : boolean {
-        stream.grow(this.calcByteLength(target));
+        stream.grow(8);
 
         const trackerOffset = stream.offset;
         ++stream.offset;

--- a/muschema/src/vector.ts
+++ b/muschema/src/vector.ts
@@ -61,12 +61,6 @@ export class MuVector<ValueSchema extends MuNumber>
         return copy;
     }
 
-    // bytes for trackers +
-    // bytes enough to hold the value of vec
-    public calcByteLength (vec:_MuVectorType<ValueSchema>) {
-        return Math.ceil(this.identity.byteLength * 9 / 8);
-    }
-
     public diff (
         base_:_MuVectorType<ValueSchema>,
         target_:_MuVectorType<ValueSchema>,
@@ -76,7 +70,7 @@ export class MuVector<ValueSchema extends MuNumber>
         const target = new Uint8Array(target_.buffer);
 
         const dimension = this.identity.byteLength;
-        stream.grow(this.calcByteLength(target));
+        stream.grow(Math.ceil(this.identity.byteLength * 9 / 8));
 
         const headPtr = stream.offset;
 

--- a/muschema/src/void.ts
+++ b/muschema/src/void.ts
@@ -14,5 +14,4 @@ export class MuVoid implements MuSchema<void> {
     public clone () : void {}
     public diff (b, t, stream:MuWriteStream) { return false; }
     public patch (b, stream:MuReadStream) : void {}
-    public calcByteLength () { return 0; }
 }


### PR DESCRIPTION
This PR removes `calcByteLength` from the `MuSchema` interface.  It also fixes a bug where writing a large struct into a small packet triggered an error.  This was due to mustruct not growing correctly.  In Box3 this was causing problems when loading voxel data for new clients.

In the new system patch is responsible for calling `MuWriteStream.grow` as bytes are written.  This is more robust and only a bit less efficient.

There are some failing test cases in `src/test/numbers`.  

@esdoppio can you take a look at this and see what's going wrong?