### PR TITLE
Support yarn for linking

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,9 +20,18 @@ By participating, you are expected to uphold [Code of Conduct](CODE_OF_CONDUCT.m
 * Install vscode (optional)
 * Linking submodules
 
-```
+One of these:
+
+```sh
+# npm
 npm run link-all
+# yarn
+yarn run link-all -- yarn
+# yarn version >= 1.0.0
+yarn run link-all yarn
 ```
+
+You may need to run your linking command twice if this is the first time you're developing on mudb.
 
 * typescript watch
 

--- a/bin/link-all.js
+++ b/bin/link-all.js
@@ -8,15 +8,22 @@ const repoContents = fs.readdirSync(repoPath)
 const muModules = repoContents.filter((filename) => filename.indexOf('mu') === 0)
 const modulePaths = muModules.map((modName) => path.join(repoPath, modName))
 
-console.log('installing dependencies and registering modules...')
+let npmish = 'npm'
+let installish = 'i'
+if (process.argv.length == 3 && process.argv[2] == 'yarn') {
+    npmish = 'yarn'
+    installish = ''
+}
+
+console.log('installing dependencies and registering modules with...')
 modulePaths.forEach((dir) => {
     const execSync = execInDirectorySync(dir)
 
     // bypass compilation errors
     try { execSync('tsc') } catch (e) { }
     execSync('rm -rf node_modules')
-    execSync('npm i')
-    execSync('npm link')
+    execSync(`${npmish} ${installish}`)
+    execSync(`${npmish} link`)
 })
 
 console.log('linking dependencies...')
@@ -28,7 +35,7 @@ modulePaths.forEach((dir) => {
         if (dependencies) {
             Object.keys(dependencies).forEach((dep) => {
                 if (dep.indexOf('mu') === 0) {
-                    exec(`npm link ${dep}`)
+                    exec(`${npmish} link ${dep}`)
                 }
             })
         }

--- a/bin/link-half.js
+++ b/bin/link-half.js
@@ -8,6 +8,11 @@ const repoContents = fs.readdirSync(repoPath)
 const muModules = repoContents.filter((filename) => filename.indexOf('mu') === 0)
 const modulePaths = muModules.map((modName) => path.join(repoPath, modName))
 
+let npmish = 'npm'
+if (process.argv.length == 3 && process.argv[2] == 'yarn') {
+    npmish = 'yarn'
+}
+
 console.log('linking dependencies...')
 modulePaths.forEach((dir) => {
     const exec = execInDirectory(dir)
@@ -17,7 +22,7 @@ modulePaths.forEach((dir) => {
         if (dependencies) {
             Object.keys(dependencies).forEach((dep) => {
                 if (dep.indexOf('mu') === 0) {
-                    exec(`npm link ${dep}`)
+                    exec(`${npmish} link ${dep}`)
                 }
             })
         }


### PR DESCRIPTION
Should be friendlier to your workflow. While `npm i` will overwrite your linked modules, `yarn` will not do so. It'll respect your links.