### PR TITLE
Improve clock stability under heavy load

### DIFF
--- a/muclock/src/fit-line.ts
+++ b/muclock/src/fit-line.ts
@@ -1,19 +1,3 @@
-// solve for model. parameters a,b.
-//  f(x) = ax + b
-//
-// loss
-//  L = sum((f(xi) - yi)^2)
-//      sum((axi + b - yi)^2)
-//      sum(a^2 xi^2 + a b xi - a xi yi + a b xi + b^2 - b yi - a xi yi - b yi + yi^2)
-//      sum(a^2 xi^2 + 2 a b xi - 2 a xi yi + b^2 - 2 b yi + yi^2)
-//
-//  dL / da = sum(2 a xi^2 + 2 b xi - 2 xi yi)
-//          ~ a sum(xi^2) + b sum(xi) - sum(xi yi)
-//
-//  dL / db = sum(2 a xi + 2 b - 2 yi)
-//          ~ a sum(xi) + n b - sum(yi)
-//
-
 class Pair {
     public x:number;
     public y:number;
@@ -42,40 +26,8 @@ function zipPairs (x:number[], y:number[]) : Pair[] {
     return pairList;
 }
 
-export function fitLine(x:number[], y:number[]) : { a:number, b:number } {
+export function fitLine(x:number[], y:number[]) {
     const pairs = zipPairs(x, y);
-
-    const startIdx = Math.floor(pairs.length * 1 / 6);
-    const endIdx = Math.ceil(pairs.length * 5 / 6);
-    const n = endIdx - startIdx;
-
-    let sumX2 = 0;
-    let sumX = 0;
-    let sumY = 0;
-    let sumXY = 0;
-
-    for (let i = startIdx; i < endIdx; ++i) {
-        const p = pairs[i];
-        const xi = p.x;
-        const yi = p.y;
-        sumX2 += xi * xi;
-        sumX += xi;
-        sumY += yi;
-        sumXY += xi * yi;
-    }
-
-    const det = sumX2 * n - sumX * sumX;
-    if (Math.abs(det) < 1e-6) {
-        const p = pairs[pairs.length >> 1];
-        return { a: 1, b: p.y - p.x };
-    }
-
-    const a0 = n / det;
-    const a1 = -sumX / det;
-    const a2 = sumX2 / det;
-
-    return {
-        a: sumXY * a0 + sumY * a1,
-        b: sumXY * a1 + sumY * a2,
-    };
+    const p = pairs[pairs.length >> 1];
+    return p.y - p.x;
 }

--- a/muclock/src/schema.ts
+++ b/muclock/src/schema.ts
@@ -9,6 +9,11 @@ export const MuClockProtocol = {
         init: new MuStruct({
             tickRate: new MuUint32(),
             serverClock: new MuFloat64(),
+            skippedFrames: new MuUint32(),
+        }),
+        frameSkip: new MuStruct({
+            skippedFrames: new MuUint32(),
+            serverClock: new MuFloat64(),
         }),
         ping: new MuUint32(),
         pong: new MuFloat64(),


### PR DESCRIPTION
This PR improves the ability of muclock to respond to variable loads.  Specifically it allows for the client clock to configure fast-forward and rewind behaviors to catch up to desynchronization bugs in the server.  It also improves the robustness of wall clock synchronization by switching from a linear least squares estimator to a simpler and better median algorithm.

* Servers can respond to heavy load by setting a `frameSkip` flag.  If more than `frameSkip` ticks are required in 1 cycle, then the server will drop them and only execute one tick.  This causes the tick counter to run slower on the server.
* Clients can also implement a frame skip which allows them to fast forward if they are running behind.  This improves performance when tabbing away from a running game.
* Clients can also set a rewind flag to recover from a server with frame skip.  If not set clients will pause until the server catches up.  Turning this on breaks the monotonicity assumption so it is off by default.
* Replaced the old linear least squares clock synchronization with a simpler median algorithm.  This seems to be working much better so it should be good to merge it in for now.