### PR TITLE
Schema: copy -> assign

### DIFF
--- a/src/schema/_number.ts
+++ b/src/schema/_number.ts
@@ -40,7 +40,7 @@ export abstract class MuNumber implements MuSchema<number> {
         return num;
     }
 
-    public copy (source:number, target:number) { }
+    public assign (dst:number, src:number) { }
 
     public toJSON (num:number) : number {
         return num;

--- a/src/schema/_string.ts
+++ b/src/schema/_string.ts
@@ -35,7 +35,7 @@ export abstract class MuString implements MuSchema<string> {
         return str;
     }
 
-    public copy (source:string, target:string) { }
+    public assign (dst:string, src:string) { }
 
     public toJSON (str:string) : string {
         return str;

--- a/src/schema/array.ts
+++ b/src/schema/array.ts
@@ -63,36 +63,36 @@ export class MuArray<ValueSchema extends MuSchema<any>>
         return copy;
     }
 
-    public copy (source:ValueSchema['identity'][], target:ValueSchema['identity'][]) {
-        if (source === target) {
+    public assign (dst:ValueSchema['identity'][], src:ValueSchema['identity'][]) {
+        if (dst === src) {
             return;
         }
 
-        const sLeng = source.length;
-        const tLeng = target.length;
+        const dLeng = dst.length;
+        const sLeng = src.length;
         const valueSchema = this.muData;
 
-        // pool extra elements in target
-        for (let i = sLeng; i < tLeng; ++i) {
-            valueSchema.free(target[i]);
+        // pool extra elements in dst
+        for (let i = sLeng; i < dLeng; ++i) {
+            valueSchema.free(dst[i]);
         }
 
-        target.length = sLeng;
+        dst.length = sLeng;
 
         if (isMuPrimitive(valueSchema.muType)) {
             for (let i = 0; i < sLeng; ++i) {
-                target[i] = source[i];
+                dst[i] = src[i];
             }
             return;
         }
 
-        // done if source has less or same number of elements
-        for (let i = 0; i < Math.min(sLeng, tLeng); ++i) {
-            valueSchema.copy(source[i], target[i]);
+        // done if src has less or same number of elements
+        for (let i = 0; i < Math.min(dLeng, sLeng); ++i) {
+            valueSchema.assign(dst[i], src[i]);
         }
-        // only if source has more elements
-        for (let i = tLeng; i < sLeng; ++i) {
-            target[i] = valueSchema.clone(source[i]);
+        // only if src has more elements
+        for (let i = dLeng; i < sLeng; ++i) {
+            dst[i] = valueSchema.clone(src[i]);
         }
     }
 

--- a/src/schema/boolean.ts
+++ b/src/schema/boolean.ts
@@ -29,7 +29,7 @@ export class MuBoolean implements MuSchema<boolean> {
         return bool;
     }
 
-    public copy (source:boolean, target:boolean) { }
+    public assign (dst:boolean, src:boolean) { }
 
     public diff (base:boolean, target:boolean, out:MuWriteStream) {
         if (base !== target) {

--- a/src/schema/dictionary.ts
+++ b/src/schema/dictionary.ts
@@ -74,37 +74,37 @@ export class MuDictionary<ValueSchema extends MuSchema<any>>
         return copy;
     }
 
-    public copy (source:_Dictionary<ValueSchema>, target:_Dictionary<ValueSchema>) {
-        if (source === target) {
+    public assign (dst:_Dictionary<ValueSchema>, src:_Dictionary<ValueSchema>) {
+        if (dst === src) {
             return;
         }
 
-        const sKeys = Object.keys(source);
-        const tKeys = Object.keys(target);
+        const dKeys = Object.keys(dst);
+        const sKeys = Object.keys(src);
         const valueSchema = this.muData;
 
-        for (let i = 0; i < tKeys.length; ++i) {
-            const k = tKeys[i];
-            if (!(k in source)) {
-                valueSchema.free(target[k]);
-                delete target[k];
+        for (let i = 0; i < dKeys.length; ++i) {
+            const k = dKeys[i];
+            if (!(k in src)) {
+                valueSchema.free(dst[k]);
+                delete dst[k];
             }
         }
 
         if (isMuPrimitive(valueSchema.muType)) {
             for (let i = 0; i < sKeys.length; ++i) {
                 const k = sKeys[i];
-                target[k] = source[k];
+                dst[k] = src[k];
             }
             return;
         }
 
         for (let i = 0; i < sKeys.length; ++i) {
             const k = sKeys[i];
-            if (k in target) {
-                valueSchema.copy(source[k], target[k]);
+            if (k in dst) {
+                valueSchema.assign(dst[k], src[k]);
             } else {
-                target[k] = valueSchema.clone(source[k]);
+                dst[k] = valueSchema.clone(src[k]);
             }
         }
     }

--- a/src/schema/schema.ts
+++ b/src/schema/schema.ts
@@ -25,8 +25,8 @@ export interface MuSchema<Value> {
     /** Makes a copy of `value` */
     clone (value:Value) : Value;
 
-    /** Copies content of `source` to `target` */
-    copy (source:Value, target:Value) : void;
+    /** Assigns `dst` the content of `src` */
+    assign (dst:Value, src:Value) : void;
 
     /** Computes a binary patch from `base` to `target` */
     diff (base:Value, target:Value, out:MuWriteStream) : boolean;

--- a/src/schema/sorted.ts
+++ b/src/schema/sorted.ts
@@ -96,36 +96,36 @@ export class MuSortedArray<ValueSchema extends MuSchema<any>>
         return copy;
     }
 
-    public copy (source:ValueSchema['identity'][], target:ValueSchema['identity'][]) {
-        if (source === target) {
+    public assign (dst:ValueSchema['identity'][], src:ValueSchema['identity'][]) {
+        if (dst === src) {
             return;
         }
 
-        const sLeng = source.length;
-        const tLeng = target.length;
+        const dLeng = dst.length;
+        const sLeng = src.length;
         const valueSchema = this.muData;
 
-        // pool extra elements in target
-        for (let i = sLeng; i < tLeng; ++i) {
-            valueSchema.free(target[i]);
+        // pool extra elements in dst
+        for (let i = sLeng; i < dLeng; ++i) {
+            valueSchema.free(dst[i]);
         }
 
-        target.length = sLeng;
+        dst.length = sLeng;
 
         if (isMuPrimitive(valueSchema.muType)) {
             for (let i = 0; i < sLeng; ++i) {
-                target[i] = source[i];
+                dst[i] = src[i];
             }
             return;
         }
 
-        // done if source has less or same number of elements
-        for (let i = 0; i < Math.min(sLeng, tLeng); ++i) {
-            valueSchema.copy(source[i], target[i]);
+        // done if src has less or same number of elements
+        for (let i = 0; i < Math.min(dLeng, sLeng); ++i) {
+            valueSchema.assign(dst[i], src[i]);
         }
-        // only if source has more elements
-        for (let i = tLeng; i < sLeng; ++i) {
-            target[i] = valueSchema.clone(source[i]);
+        // only if src has more elements
+        for (let i = dLeng; i < sLeng; ++i) {
+            dst[i] = valueSchema.clone(src[i]);
         }
     }
 

--- a/src/schema/struct.ts
+++ b/src/schema/struct.ts
@@ -26,7 +26,7 @@ export class MuStruct<Spec extends { [propName:string]:MuSchema<any> }>
     public readonly equal:(a:_Struct<Spec>, b:_Struct<Spec>) => boolean;
 
     public readonly clone:(value:_Struct<Spec>) => _Struct<Spec>;
-    public readonly copy:(source:_Struct<Spec>, target:_Struct<Spec>) => void = (source, target) => {};
+    public readonly assign:(dst:_Struct<Spec>, src:_Struct<Spec>) => void;
 
     public readonly diff:(base:_Struct<Spec>, target:_Struct<Spec>, out:MuWriteStream) => boolean;
     public readonly patch:(base:_Struct<Spec>, inp:MuReadStream) => _Struct<Spec>;
@@ -116,7 +116,7 @@ export class MuStruct<Spec extends { [propName:string]:MuSchema<any> }>
             free: func('free', ['x']),
             equal: func('equal', ['a', 'b']),
             clone: func('clone', ['x']),
-            copy: func('copy', ['s', 't']),
+            assign: func('assign', ['d', 's']),
             diff: func('diff', ['b', 't', 's']),
             patch: func('patch', ['b', 's']),
             toJSON: func('toJSON', ['s']),
@@ -266,13 +266,13 @@ export class MuStruct<Spec extends { [propName:string]:MuSchema<any> }>
         });
         methods.clone.append('return result');
 
-        // copy subroutine
+        // assign subroutine
         propRefs.forEach((propRef, i) => {
             const type = structTypes[i];
             switch (type.muType) {
                 case 'ascii':
-                case 'fascii':
                 case 'boolean':
+                case 'fascii':
                 case 'float32':
                 case 'float64':
                 case 'int8':
@@ -282,10 +282,10 @@ export class MuStruct<Spec extends { [propName:string]:MuSchema<any> }>
                 case 'uint16':
                 case 'uint32':
                 case 'utf8':
-                    methods.copy.append(`t[${propRef}]=s[${propRef}];`);
+                    methods.assign.append(`d[${propRef}]=s[${propRef}];`);
                     break;
                 default:
-                    methods.copy.append(`${typeRefs[i]}.copy(s[${propRef}],t[${propRef}]);`);
+                    methods.assign.append(`${typeRefs[i]}.assign(d[${propRef}],s[${propRef}]);`);
             }
         });
 
@@ -412,7 +412,7 @@ export class MuStruct<Spec extends { [propName:string]:MuSchema<any> }>
         this.free = compiled.free;
         this.equal = compiled.equal;
         this.clone = compiled.clone;
-        this.copy = compiled.copy;
+        this.assign = compiled.assign;
         this.diff = compiled.diff;
         this.patch = compiled.patch;
         this.toJSON = compiled.toJSON;

--- a/src/schema/test/array.ts
+++ b/src/schema/test/array.ts
@@ -127,21 +127,21 @@ test('array (nested) - clone()', (t) => {
     t.end();
 });
 
-test('array - copy()', (t) => {
+test('array - assign()', (t) => {
     for (const muType of muPrimitiveTypes) {
         const valueSchema = muPrimitiveSchema(muType);
         if (valueSchema) {
-            let source:any[];
-            let target:any[];
+            let dst:any[];
+            let src:any[];
 
             let arraySchema = new MuArray(valueSchema);
 
             for (let i = 0; i < 10; ++i) {
-                source = randomArray(1, muType);
-                target = randomArray(1, muType);
+                dst = randomArray(1, muType);
+                src = randomArray(1, muType);
 
-                arraySchema.copy(source, target);
-                t.deepEqual(target, source);
+                arraySchema.assign(dst, src);
+                t.deepEqual(dst, src);
             }
 
             arraySchema = new MuArray(
@@ -149,11 +149,11 @@ test('array - copy()', (t) => {
             );
 
             for (let i = 0; i < 10; ++i) {
-                source = randomArray(2, muType);
-                target = randomArray(2, muType);
+                dst = randomArray(2, muType);
+                src = randomArray(2, muType);
 
-                arraySchema.copy(source, target);
-                t.deepEqual(target, source);
+                arraySchema.assign(dst, src);
+                t.deepEqual(dst, src);
             }
 
             arraySchema = new MuArray(
@@ -163,11 +163,11 @@ test('array - copy()', (t) => {
             );
 
             for (let i = 0; i < 10; ++i) {
-                source = randomArray(3, muType);
-                target = randomArray(3, muType);
+                dst = randomArray(3, muType);
+                src = randomArray(3, muType);
 
-                arraySchema.copy(source, target);
-                t.deepEqual(target, source);
+                arraySchema.assign(dst, src);
+                t.deepEqual(dst, src);
             }
         }
     }

--- a/src/schema/test/dictionary.ts
+++ b/src/schema/test/dictionary.ts
@@ -208,21 +208,21 @@ test('dictionary (nested) - clone()', (t) => {
     t.end();
 });
 
-test('dictionary - copy()', (t) => {
+test('dictionary - assign()', (t) => {
     for (const muType of muPrimitiveTypes) {
         const valueSchema = muPrimitiveSchema(muType);
         if (valueSchema) {
-            let source;
-            let target;
+            let dst;
+            let src;
 
             let dictionarySchema = new MuDictionary(valueSchema);
 
             for (let i = 0; i < 10; ++i) {
-                source = randomDictionary(1, muType, randomString);
-                target = randomDictionary(1, muType, randomString);
+                dst = randomDictionary(1, muType, randomString);
+                src = randomDictionary(1, muType, randomString);
 
-                dictionarySchema.copy(source, target);
-                t.deepEqual(target, source);
+                dictionarySchema.assign(dst, src);
+                t.deepEqual(dst, src);
             }
 
             dictionarySchema = new MuDictionary(
@@ -230,11 +230,11 @@ test('dictionary - copy()', (t) => {
             );
 
             for (let i = 0; i < 10; ++i) {
-                source = randomDictionary(2, muType, randomString);
-                target = randomDictionary(2, muType, randomString);
+                dst = randomDictionary(2, muType, randomString);
+                src = randomDictionary(2, muType, randomString);
 
-                dictionarySchema.copy(source, target);
-                t.deepEqual(target, source);
+                dictionarySchema.assign(dst, src);
+                t.deepEqual(dst, src);
             }
 
             dictionarySchema = new MuDictionary(
@@ -244,11 +244,11 @@ test('dictionary - copy()', (t) => {
             );
 
             for (let i = 0; i < 10; ++i) {
-                source = randomDictionary(3, muType, randomString);
-                target = randomDictionary(3, muType, randomString);
+                dst = randomDictionary(3, muType, randomString);
+                src = randomDictionary(3, muType, randomString);
 
-                dictionarySchema.copy(source, target);
-                t.deepEqual(target, source);
+                dictionarySchema.assign(dst, src);
+                t.deepEqual(dst, src);
             }
         }
     }

--- a/src/schema/test/struct.ts
+++ b/src/schema/test/struct.ts
@@ -78,7 +78,7 @@ test('struct - equal()', (t) => {
     t.end();
 });
 
-test('struct - copy()', (t) => {
+test('struct - assign()', (t) => {
     const structSchema = new MuStruct({
         s: new MuStruct({
             s: new MuStruct({
@@ -98,24 +98,24 @@ test('struct - copy()', (t) => {
         }),
     });
 
-    const source = structSchema.alloc();
-    const target = structSchema.alloc();
+    const dst = structSchema.alloc();
+    const src = structSchema.alloc();
 
-    source.s.s.a = randomValue('ascii');
-    source.s.s.b = true;
-    source.s.s.fa = 'abcde';
-    source.s.s.f32 = randomValue('float32');
-    source.s.s.f64 = randomValue('float64');
-    source.s.s.i8 = randomValue('int8');
-    source.s.s.i16 = randomValue('int16');
-    source.s.s.i32 = randomValue('int32');
-    source.s.s.u8 = randomValue('uint8');
-    source.s.s.u16 = randomValue('uint16');
-    source.s.s.u32 = randomValue('uint32');
-    source.s.s.utf8 = randomValue('utf8');
+    src.s.s.a = randomValue('ascii');
+    src.s.s.b = true;
+    src.s.s.fa = 'abcde';
+    src.s.s.f32 = randomValue('float32');
+    src.s.s.f64 = randomValue('float64');
+    src.s.s.i8 = randomValue('int8');
+    src.s.s.i16 = randomValue('int16');
+    src.s.s.i32 = randomValue('int32');
+    src.s.s.u8 = randomValue('uint8');
+    src.s.s.u16 = randomValue('uint16');
+    src.s.s.u32 = randomValue('uint32');
+    src.s.s.utf8 = randomValue('utf8');
 
-    structSchema.copy(source, target);
-    t.deepEqual(target, source);
+    structSchema.assign(dst, src);
+    t.deepEqual(dst, src);
 
     t.end();
 });

--- a/src/schema/trace.ts
+++ b/src/schema/trace.ts
@@ -94,8 +94,8 @@ export class MuSchemaTrace<BaseSchema extends MuSchema<any>>
         return this.schema.clone(x);
     }
 
-    public copy (source:BaseSchema['identity'], target:BaseSchema['identity']) {
-        this.schema.copy(source, target);
+    public assign (dst:BaseSchema['identity'], src:BaseSchema['identity']) {
+        this.schema.assign(dst, src);
     }
 
     public diff (base:BaseSchema['identity'], target:BaseSchema['identity'], out:MuWriteStream) : boolean {

--- a/src/schema/union.ts
+++ b/src/schema/union.ts
@@ -104,29 +104,28 @@ export class MuUnion<SubTypes extends { [type:string]:MuSchema<any> }>
         };
     }
 
-    public copy (source:_Union<SubTypes>, target:_Union<SubTypes>) {
-        if (source === target) {
+    public assign (dst:_Union<SubTypes>, src:_Union<SubTypes>) {
+        if (dst === src) {
             return;
         }
 
-        const sType = source.type;
-        const tType = target.type;
+        const dType = dst.type;
+        const sType = src.type;
         const valueSchema = this.muData;
 
-        target.type = source.type;
+        dst.type = src.type;
 
-        if (sType !== tType) {
-            valueSchema[tType].free(target.data);
-            target.data = valueSchema[sType].clone(source.data);
+        if (dType !== sType) {
+            valueSchema[dType].free(dst.data);
+            dst.data = valueSchema[sType].clone(src.data);
             return;
         }
 
         // same type
-        if (isMuPrimitive(valueSchema[sType].muType)) {
-            target.data = source.data;
-            return;
+        valueSchema[dType].assign(dst.data, src.data);
+        if (isMuPrimitive(valueSchema[dType].muType)) {
+            dst.data = src.data;
         }
-        valueSchema[sType].copy(source.data, target.data);
     }
 
     public diff (

--- a/src/schema/vector.ts
+++ b/src/schema/vector.ts
@@ -77,11 +77,11 @@ export class MuVector<ValueSchema extends MuNumber>
         return copy;
     }
 
-    public copy (source:_Vector<ValueSchema>, target:_Vector<ValueSchema>) {
-        if (source === target) {
+    public assign (dst:_Vector<ValueSchema>, src:_Vector<ValueSchema>) {
+        if (dst === src) {
             return;
         }
-        target.set(source);
+        dst.set(src);
     }
 
     public diff (

--- a/src/schema/void.ts
+++ b/src/schema/void.ts
@@ -13,7 +13,7 @@ export class MuVoid implements MuSchema<void> {
     public free (_:void) : void { }
     public equal (a:void, b:void) { return true; }
     public clone (_:void) : void { }
-    public copy (s:void, t:void) { }
+    public assign (d:void, s:void) { }
     public diff (b, t, out:MuWriteStream) { return false; }
     public patch (b, inp:MuReadStream) : void { }
     public toJSON (_:void) : null { return null; }


### PR DESCRIPTION
Aiming to improve UX:
* help distinguish the method from clone()
* assign(dst, src) mimics the semantics of dst = src