### PR TITLE
Make utf8 encode/decode public

### DIFF
--- a/src/stream/index.ts
+++ b/src/stream/index.ts
@@ -16,6 +16,9 @@ if (typeof root === 'object' && 'TextEncoder' in root) {
     decodeString = StringCodec.decodeString;
 }
 
+export const encodeUTF8 = encodeString;
+export const decodeUTF8 = decodeString;
+
 // round to next highest power of 2
 function ceilLog2 (v_) {
     let v = v_ - 1;


### PR DESCRIPTION
There's a duplicate (and broken) implementation of these methods in box3.  If we expose them in mudb it would make the code simpler and more robust.