### PR TITLE
Remove MuTrace, replace with a generic logging interface

### DIFF
--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,0 +1,11 @@
+export interface MuLogger {
+    log:(mesg:string) => void;
+    error:(mesg:string) => void;
+    exception:(e:Error) => void;
+}
+
+export const MuDefaultLogger = {
+    log: () => {},
+    error: (x:string) => console.log(`mudb error: ${x}`),
+    exception: console.error,
+};

--- a/src/protocol.ts
+++ b/src/protocol.ts
@@ -2,7 +2,7 @@ import { MuSchema } from './schema/schema';
 import { MuWriteStream, MuReadStream } from './stream';
 
 import { MuSocket, MuData } from './socket/socket';
-import { MuTrace } from './trace';
+import { MuLogger } from './logger';
 
 import stableStringify = require('./util/stringify');
 import sha512 = require('hash.js/lib/hash/sha/512');
@@ -118,7 +118,6 @@ export class MuMessageFactory {
 
 export class MuProtocolFactory {
     public protocolFactories:MuMessageFactory[];
-
     public hash:string;
 
     constructor (protocolSchemas:MuAnyMessageTable[]) {
@@ -133,7 +132,7 @@ export class MuProtocolFactory {
             messageHandlers:{ [name:string]:(data, unreliable) => void },
             rawHandler:(data, unreliable) => void,
         }[],
-        trace:MuTrace | null,
+        logger:MuLogger,
     ) {
         const raw = spec.map((h) => h.rawHandler);
         const message = spec.map(({messageHandlers}, id) =>
@@ -154,9 +153,6 @@ export class MuProtocolFactory {
 
                 if (object.s) {
                     raw[protocolId](object.s, unreliable);
-                    if (trace) {
-                        trace.logMessage(protocolId, object.s);
-                    }
                 }
             } else {
                 const stream = new MuReadStream(data);
@@ -192,10 +188,6 @@ export class MuProtocolFactory {
                 }
                 message[protocolId][messageId](m, unreliable);
                 messageSchema.free(m);
-
-                if (trace) {
-                    trace.logMessage(protocolId, m, messageSchema);
-                }
             }
         };
     }

--- a/src/replica/server.ts
+++ b/src/replica/server.ts
@@ -4,6 +4,7 @@ import { rdaProtocol, RDAProtocol } from './schema';
 import { MuSessionId } from '../socket/socket';
 import { MuScheduler } from '../scheduler/scheduler';
 import { MuSystemScheduler } from '../scheduler/system';
+import { MuLogger, MuDefaultLogger } from '../logger';
 
 export class MuReplicaServer<RDA extends MuRDA<any, any, any, any>> {
     public protocol:MuServerProtocol<RDAProtocol<RDA>>;
@@ -12,13 +13,17 @@ export class MuReplicaServer<RDA extends MuRDA<any, any, any, any>> {
 
     public scheduler:MuScheduler;
 
+    private _logger:MuLogger;
+
     constructor (spec:{
         server:MuServer,
         rda:RDA,
         savedStore?:MuRDATypes<RDA>['serializedStore'],
         initialState?:MuRDATypes<RDA>['state'],
         scheduler?:MuScheduler,
+        logger?:MuLogger,
     }) {
+        this._logger = spec.logger || MuDefaultLogger;
         this.rda = spec.rda;
         if ('savedStore' in spec) {
             this.store = <MuRDATypes<RDA>['store']>this.rda.parse(spec.savedStore);
@@ -80,6 +85,7 @@ export class MuReplicaServer<RDA extends MuRDA<any, any, any, any>> {
             message: {
                 apply: (client, action) => {
                     if (spec.checkApply && !spec.checkApply(action, client.sessionId)) {
+                        this._logger.log(`invalid action ${JSON.stringify} from ${client.sessionId}`);
                         return;
                     }
                     this.dispatch(action);

--- a/src/socket/uws/client.ts
+++ b/src/socket/uws/client.ts
@@ -1,4 +1,5 @@
 import { MuSocket, MuSocketState, MuSocketSpec, MuSessionId, MuData } from '../socket';
+import { MuLogger, MuDefaultLogger } from '../../logger';
 
 const isBrowser = typeof window === 'object' && !!window && 'addEventListener' in window;
 
@@ -26,17 +27,22 @@ export class MuUWSSocket implements MuSocket {
     private _unreliableSockets:WebSocket[] = [];
     private _nextUnreliable = 0;
 
+    private _logger:MuLogger;
+
     constructor (spec:{
         sessionId:MuSessionId,
         url:string,
         maxSockets?:number,
         ws?:WebSocketConstructor,
+        logger?:MuLogger,
     }) {
+        this._logger = spec.logger || MuDefaultLogger;
+
         if (isBrowser) {
             if (!browserWS) {
                 throw new Error(`no WebSocket support in browser [mudb/socket/web/client]`);
             } else if (spec.ws) {
-                console.warn(`Any third-party WebSocket binding will be ignored in browser environment`);
+                this._logger.log(`Any third-party WebSocket binding will be ignored in browser environment`);
             }
         }
         if (!isBrowser && !spec.ws) {
@@ -151,7 +157,7 @@ export class MuUWSSocket implements MuSocket {
             return;
         }
         if (this.state === MuSocketState.INIT) {
-            console.warn(`closing socket before fully open [mudb/socket/uws/client]`);
+            this._logger.log(`closing socket before fully open [mudb/socket/uws/client]`);
         }
 
         this.state = MuSocketState.CLOSED;

--- a/src/socket/uws/server.ts
+++ b/src/socket/uws/server.ts
@@ -10,6 +10,7 @@ import {
 } from '../socket';
 import { MuScheduler } from '../../scheduler/scheduler';
 import { MuSystemScheduler } from '../../scheduler/system';
+import { MuLogger, MuDefaultLogger } from '../../logger';
 
 function noop () { }
 
@@ -128,10 +129,14 @@ export class MuUWSSocketServer implements MuSocketServer {
 
     private _scheduler:MuScheduler;
 
+    private _logger:MuLogger;
+
     constructor (spec:{
         server:uWS.TemplatedApp,
         scheduler?:MuScheduler,
+        logger?:MuLogger,
     }) {
+        this._logger = spec.logger || MuDefaultLogger;
         this._server = spec.server;
         this._scheduler = spec.scheduler || MuSystemScheduler;
     }
@@ -209,13 +214,13 @@ export class MuUWSSocketServer implements MuSocketServer {
     }) {
         const onlistening = (ls:uWS.us_listen_socket) => {
             if (ls) {
-                console.log(`server listening to port ${spec.port}...`);
+                this._logger.log(`server listening to port ${spec.port}...`);
                 this._listenSocket = ls;
                 if (spec.listening) {
                     spec.listening(ls);
                 }
             } else {
-                console.error(`server failed to listen to port ${spec.port}`);
+                this._logger.error(`server failed to listen to port ${spec.port}`);
             }
         };
 
@@ -231,7 +236,7 @@ export class MuUWSSocketServer implements MuSocketServer {
             return;
         }
         if (this.state === MuSocketServerState.INIT) {
-            console.warn(`shutting down socket server before fully started [mudb/socket/uws/server]`);
+            this._logger.log(`shutting down socket server before fully started [mudb/socket/uws/server]`);
         }
 
         this.state = MuSocketServerState.SHUTDOWN;


### PR DESCRIPTION
This PR simplifies how the logging works.  The previous tracing stuff is kind of janky and doesn't really do what we need.

There's now a new generic logging interface which can be passed in and used to redirect logging to whatever sink is required.