### PR TITLE
New protocol prefix encoding

### DIFF
--- a/src/protocol.ts
+++ b/src/protocol.ts
@@ -4,8 +4,6 @@ import { MuSocket, MuData } from './socket/socket';
 import { MuLogger } from './logger';
 import stableStringify = require('./util/stringify');
 
-const RAW_MESSAGE = 0;
-
 export type MuAnySchema = MuSchema<any>;
 export type MuMessageType = MuAnySchema;
 export interface MuAnyMessageTable {
@@ -42,18 +40,17 @@ export type MuProtocolBandwidthUsage = {
 
 export class MuMessageFactory {
     public protocolId:number;
+    public protocolShift:number;
     public schemas:MuAnySchema[];
     public messageNames:string[];
-    public messageIdTable:{ [name:string]:number } = {};
     public jsonStr:string;
 
-    constructor (schema:MuAnyMessageTable, protocolId:number) {
-        this.protocolId = protocolId;
+    public messageBase:number = 0;
 
+    constructor (schema:MuAnyMessageTable) {
         this.messageNames = Object.keys(schema).sort();
         this.schemas = new Array(this.messageNames.length);
         this.messageNames.forEach((name, id) => {
-            this.messageIdTable[name] = id;
             this.schemas[id] = schema[name];
         });
 
@@ -66,11 +63,12 @@ export class MuMessageFactory {
 
         this.messageNames.forEach((name, messageId) => {
             const schema = this.schemas[messageId];
+            const messageCode = this.messageBase + messageId + 1;
+
             result[name] = (data, unreliable?:boolean) => {
                 const stream = new MuWriteStream(128);
 
-                stream.writeVarint(this.protocolId);
-                stream.writeVarint(messageId + 1);
+                stream.writeVarint(messageCode);
                 schema.diff(schema.identity, data, stream);
 
                 const contentBytes = stream.bytes();
@@ -90,11 +88,12 @@ export class MuMessageFactory {
 
     public createSendRaw (sockets:MuSocket[], acc:MuProtocolBandwidthUsage) {
         const p = this.protocolId;
+        const rawCode = this.messageBase;
 
         return function (data:MuData, unreliable?:boolean) {
             if (typeof data === 'string') {
                 const packet = JSON.stringify({
-                    p,
+                    p: rawCode,
                     s: data,
                 });
                 const numBytes = packet.length << 1;
@@ -104,11 +103,10 @@ export class MuMessageFactory {
                     acc[socket.sessionId].sent['raw'] = (acc[socket.sessionId].sent['raw'] || 0) + numBytes;
                 }
             } else {
-                const size = 10 + data.length;
+                const size = 5 + data.length;
                 const stream = new MuWriteStream(size);
 
-                stream.writeVarint(p);
-                stream.writeVarint(RAW_MESSAGE);
+                stream.writeVarint(rawCode);
                 const { uint8 } = stream.buffer;
                 uint8.set(data, stream.offset);
                 stream.offset += data.length;
@@ -128,11 +126,17 @@ export class MuMessageFactory {
 }
 
 export class MuProtocolFactory {
-    public protocolFactories:MuMessageFactory[];
+    public protocolFactories:MuMessageFactory[] = [];
     public jsonStr:string;
 
     constructor (protocolSchemas:MuAnyMessageTable[]) {
-        this.protocolFactories = protocolSchemas.map((schema, id) => new MuMessageFactory(schema, id));
+        let count = 0;
+        for (let i = 0; i < protocolSchemas.length; ++i) {
+            const factory = new MuMessageFactory(protocolSchemas[i]);
+            factory.messageBase = count;
+            count += factory.messageNames.length + 1;
+        }
+
         this.jsonStr = this.protocolFactories.map((factory) => factory.jsonStr).join();
     }
 
@@ -145,12 +149,21 @@ export class MuProtocolFactory {
         acc:MuProtocolBandwidthUsage[],
         sessionId:string,
     ) {
-        const raw = spec.map((h) => h.rawHandler);
-        const message = spec.map(({messageHandlers}, id) =>
-            this.protocolFactories[id].messageNames.map(
-                (name) => messageHandlers[name],
-            ),
-        );
+        // precalculate schema and handler tables
+        const schemaTable:(MuAnySchema|null)[] = [];
+        const handlerTable:((x:any, unreliable:boolean) => void)[] = [];
+        spec.forEach(({ messageHandlers, rawHandler }, id) => {
+            // add entry for raw handler
+            schemaTable.push(null);
+            handlerTable.push(rawHandler);
+
+            // append message handlers
+            const { messageNames, schemas } = this.protocolFactories[id];
+            for (let i = 0; i < messageNames.length; ++i) {
+                schemaTable.push(schemas[i]);
+                handlerTable.push(messageHandlers[messageNames[i]]);
+            }
+        });
 
         return (data:MuData, unreliable:boolean) => {
             if (typeof data === 'string') {
@@ -163,46 +176,38 @@ export class MuProtocolFactory {
                 }
 
                 if (object.s) {
-                    raw[protocolId](object.s, unreliable);
+                    handlerTable[protocolId].call(null, object.s, unreliable);
                     acc[protocolId][sessionId].received['raw'] = (acc[protocolId][sessionId].received['raw'] || 0) + (data.length << 1);
                 }
             } else {
                 const stream = new MuReadStream(data);
 
-                const protocolId = stream.readVarint();
-                const protocol = this.protocolFactories[protocolId];
-                if (!protocol) {
-                    throw new Error(`invalid protocol id ${protocolId}`);
+                // read stream code
+                const code = stream.readVarint();
+                if (code < 0 || code >= schemaTable.length) {
+                    throw new Error(`invalid message code: ${code}`);
                 }
 
-                let messageId = stream.readVarint();
+                const handler = handlerTable[code];
+                const messageSchema = schemaTable[code];
 
-                if (messageId === RAW_MESSAGE) {
-                    raw[protocolId](stream.bytes(), unreliable);
-                    acc[protocolId][sessionId].received['raw'] = (acc[protocolId][sessionId].received['raw'] || 0) + data.byteLength;
+                // FIXME: could just store a reference to the stats counters here
+                // acc[protocolId][sessionId].received[messageName] = (acc[protocolId][sessionId].received[messageName] || 0) + data.byteLength;
+
+                // null schema implies a raw handler
+                if (!messageSchema) {
+                    handler.call(null, stream.bytes(), unreliable);
                     return;
                 }
-                messageId -= 1;
 
-                const messageSchema = protocol.schemas[messageId];
-                if (!messageSchema) {
-                    throw new Error(`invalid message id ${messageId}`);
-                }
-
-                const handlers = message[protocolId];
-                if (!handlers || !handlers[messageId]) {
-                    throw new Error(`cannot find handler`);
-                }
-
+                // parse message
                 let m;
                 if (stream.offset < stream.length) {
                     m = messageSchema.patch(messageSchema.identity, stream);
                 } else {
                     m = messageSchema.clone(messageSchema.identity);
                 }
-                message[protocolId][messageId](m, unreliable);
-                const messageName = protocol.messageNames[messageId];
-                acc[protocolId][sessionId].received[messageName] = (acc[protocolId][sessionId].received[messageName] || 0) + data.byteLength;
+                handler.call(null, m, unreliable);
                 messageSchema.free(m);
             }
         };


### PR DESCRIPTION
This PR simplifies protocol parsing and serialization in mudb.

Instead of writing a separate protocol and message id, the fields are now combined into a single global counter.  This is a more optimal encoding and reduces the number of lookups and bytes written for short messages.  (A common case in the ping/keep alive messages in box3).