### PR TITLE
Schema optimization

### DIFF
--- a/src/schema/array.ts
+++ b/src/schema/array.ts
@@ -121,7 +121,7 @@ export class MuArray<ValueSchema extends MuSchema<any>>
         out.grow(4 + numTrackers);
 
         const head = out.offset;
-        out.writeUint32(tLeng);
+        out.writeVarint(tLeng);
         let trackerOffset = out.offset;
         out.offset += numTrackers;
 
@@ -165,7 +165,7 @@ export class MuArray<ValueSchema extends MuSchema<any>>
         base:ValueSchema['identity'][],
         inp:MuReadStream,
     ) : ValueSchema['identity'][] {
-        const tLeng = inp.readUint32();
+        const tLeng = inp.readVarint();
         if (tLeng > this.capacity) {
             throw new RangeError(`target length ${tLeng} exceeds capacity ${this.capacity}`);
         }

--- a/src/schema/ascii.ts
+++ b/src/schema/ascii.ts
@@ -9,7 +9,7 @@ export class MuASCII extends MuString<'ascii'> {
     public diff (base:string, target:string, out:MuWriteStream) : boolean {
         if (base !== target) {
             out.grow(5 + target.length);
-            out.writeUint32(target.length);
+            out.writeVarint(target.length);
             out.writeASCII(target);
             return true;
         }
@@ -17,6 +17,6 @@ export class MuASCII extends MuString<'ascii'> {
     }
 
     public patch (base:string, inp:MuReadStream) : string {
-        return inp.readASCII(inp.readUint32());
+        return inp.readASCII(inp.readVarint());
     }
 }

--- a/src/schema/bench/array.ts
+++ b/src/schema/bench/array.ts
@@ -1,26 +1,27 @@
 import { MuArray, MuASCII } from '../';
 import { deltaByteLength, diffPatchDuration } from './_do';
 
-const uint8Array = new MuArray(new MuASCII(), Infinity);
+const array = new MuArray(new MuASCII(), Infinity);
 
-deltaByteLength(uint8Array, [], ['a']);
-deltaByteLength(uint8Array, [], ['a', 'b']);
-deltaByteLength(uint8Array, [], ['a', 'b', 'c']);
-deltaByteLength(uint8Array, ['a'], ['a', 'b']);
-deltaByteLength(uint8Array, ['b'], ['a', 'b']);
+deltaByteLength(array, [], ['a']);
+deltaByteLength(array, [], ['a', 'b']);
+deltaByteLength(array, [], ['a', 'b', 'c']);
+deltaByteLength(array, ['a'], ['a', 'b']);
+deltaByteLength(array, ['b'], ['a', 'b']);
 
-deltaByteLength(uint8Array, ['a'], []);
-deltaByteLength(uint8Array, ['a', 'b'], []);
-deltaByteLength(uint8Array, ['a', 'b'], ['a']);
-deltaByteLength(uint8Array, ['a', 'b', 'c'], ['a']);
+deltaByteLength(array, ['a'], []);
+deltaByteLength(array, ['a', 'b'], []);
+deltaByteLength(array, ['a', 'b'], ['a']);
+deltaByteLength(array, ['a', 'b', 'c'], ['a']);
 
-deltaByteLength(uint8Array, ['a'], ['b']);
-deltaByteLength(uint8Array, ['a', 'b'], ['b', 'c']);
+deltaByteLength(array, ['a'], ['b']);
+deltaByteLength(array, ['a', 'b'], ['b', 'c']);
 
-const a1 = ['a', 'a', 'a', 'a', 'a'];
-const a2 = ['b', 'c', 'd', 'e', 'f'];
+const a0 = [];
+const a1 = ['a', 'b', 'c', 'd', 'e'];
 
-diffPatchDuration(uint8Array, a1, a1, 1e3);
+diffPatchDuration(array, a1, a1, 1e3);
 
-diffPatchDuration(uint8Array, a1, a2, 1e3);
-diffPatchDuration(uint8Array, a1, a2, 1e5);
+diffPatchDuration(array, a0, a1, 1e3);
+diffPatchDuration(array, a0, a1, 1e4);
+diffPatchDuration(array, a0, a1, 1e5);

--- a/src/schema/bench/array.ts
+++ b/src/schema/bench/array.ts
@@ -1,24 +1,24 @@
-import { MuArray, MuUint8 } from '../';
+import { MuArray, MuASCII } from '../';
 import { deltaByteLength, diffPatchDuration } from './_do';
 
-const uint8Array = new MuArray(new MuUint8(), Infinity);
+const uint8Array = new MuArray(new MuASCII(), Infinity);
 
-deltaByteLength(uint8Array, [], [0]);
-deltaByteLength(uint8Array, [], [0, 1]);
-deltaByteLength(uint8Array, [], [0, 1, 2]);
-deltaByteLength(uint8Array, [0], [0, 1]);
-deltaByteLength(uint8Array, [1], [0, 1]);
+deltaByteLength(uint8Array, [], ['a']);
+deltaByteLength(uint8Array, [], ['a', 'b']);
+deltaByteLength(uint8Array, [], ['a', 'b', 'c']);
+deltaByteLength(uint8Array, ['a'], ['a', 'b']);
+deltaByteLength(uint8Array, ['b'], ['a', 'b']);
 
-deltaByteLength(uint8Array, [0], []);
-deltaByteLength(uint8Array, [0, 1], []);
-deltaByteLength(uint8Array, [0, 1], [0]);
-deltaByteLength(uint8Array, [0, 1, 2], [0]);
+deltaByteLength(uint8Array, ['a'], []);
+deltaByteLength(uint8Array, ['a', 'b'], []);
+deltaByteLength(uint8Array, ['a', 'b'], ['a']);
+deltaByteLength(uint8Array, ['a', 'b', 'c'], ['a']);
 
-deltaByteLength(uint8Array, [0], [2]);
-deltaByteLength(uint8Array, [0, 1], [1, 2]);
+deltaByteLength(uint8Array, ['a'], ['b']);
+deltaByteLength(uint8Array, ['a', 'b'], ['b', 'c']);
 
-const a1 = [0, 0, 0, 0, 0];
-const a2 = [1, 2, 3, 4, 5];
+const a1 = ['a', 'a', 'a', 'a', 'a'];
+const a2 = ['b', 'c', 'd', 'e', 'f'];
 
 diffPatchDuration(uint8Array, a1, a1, 1e3);
 

--- a/src/schema/bench/array.ts
+++ b/src/schema/bench/array.ts
@@ -3,9 +3,6 @@ import { deltaByteLength, diffPatchDuration } from './_do';
 
 const uint8Array = new MuArray(new MuUint8(), Infinity);
 
-deltaByteLength(uint8Array, [], []);
-deltaByteLength(uint8Array, [0], [0]);
-
 deltaByteLength(uint8Array, [], [0]);
 deltaByteLength(uint8Array, [], [0, 1]);
 deltaByteLength(uint8Array, [], [0, 1, 2]);
@@ -23,13 +20,7 @@ deltaByteLength(uint8Array, [0, 1], [1, 2]);
 const a1 = [0, 0, 0, 0, 0];
 const a2 = [1, 2, 3, 4, 5];
 
-diffPatchDuration(uint8Array, a1, a1, 1);
-diffPatchDuration(uint8Array, a1, a1, 10);
-diffPatchDuration(uint8Array, a1, a1, 100);
 diffPatchDuration(uint8Array, a1, a1, 1e3);
 
-diffPatchDuration(uint8Array, a1, a2, 10);
-diffPatchDuration(uint8Array, a1, a2, 100);
-diffPatchDuration(uint8Array, a1, a2, 1000);
-diffPatchDuration(uint8Array, a1, a2, 1e4);
+diffPatchDuration(uint8Array, a1, a2, 1e3);
 diffPatchDuration(uint8Array, a1, a2, 1e5);

--- a/src/schema/bench/date.ts
+++ b/src/schema/bench/date.ts
@@ -1,0 +1,6 @@
+import { MuDate } from '../date';
+import { deltaByteLength, diffPatchDuration } from './_do';
+
+const date = new MuDate(new Date(0));
+deltaByteLength(date, new Date(0), new Date());
+diffPatchDuration(date, new Date(0), new Date(), 1e3);

--- a/src/schema/bench/dictionary.ts
+++ b/src/schema/bench/dictionary.ts
@@ -1,42 +1,26 @@
 import { MuDictionary, MuUint8 } from '../';
 import { deltaByteLength, diffPatchDuration } from './_do';
 
-const uint8Dictionary = new MuDictionary(new MuUint8(), Infinity);
+const dict = new MuDictionary(new MuUint8(), Infinity);
 
-deltaByteLength(uint8Dictionary, {}, {});
-deltaByteLength(uint8Dictionary, {a: 0}, {a: 0});
+deltaByteLength(dict, {}, {a: 0});
+deltaByteLength(dict, {}, {a: 0, b: 1});
+deltaByteLength(dict, {}, {a: 0, b: 1, c: 2});
+deltaByteLength(dict, {}, {pool: 0});
+deltaByteLength(dict, {}, {pool: 0, preface: 1});
+deltaByteLength(dict, {}, {pool: 0, preface: 1, prefix: 2});
+deltaByteLength(dict, {}, {pool: 0, preface: 1, prefix: 2, prefixed: 3});
 
-deltaByteLength(uint8Dictionary, {}, {a: 0});
-deltaByteLength(uint8Dictionary, {}, {a: 0, b: 1});
-deltaByteLength(uint8Dictionary, {}, {a: 0, b: 1, c: 2});
-deltaByteLength(uint8Dictionary, {a: 0}, {a: 0, b: 1});
-deltaByteLength(uint8Dictionary, {b: 1}, {a: 0, b: 1});
-deltaByteLength(uint8Dictionary, {a: 1}, {a: 0, b: 1});
-deltaByteLength(uint8Dictionary, {b: 0}, {a: 0, b: 1});
-
-deltaByteLength(uint8Dictionary, {a: 0}, {});
-deltaByteLength(uint8Dictionary, {a: 0, b: 1}, {});
-deltaByteLength(uint8Dictionary, {a: 0, b: 1, c: 2}, {});
-deltaByteLength(uint8Dictionary, {a: 0, b: 1}, {a: 0});
-deltaByteLength(uint8Dictionary, {a: 0, b: 1}, {b: 1});
-deltaByteLength(uint8Dictionary, {a: 0, b: 1, c: 2}, {a: 0, b: 1});
-
-deltaByteLength(uint8Dictionary, {a: 0}, {a: 1});
-deltaByteLength(uint8Dictionary, {a: 0, b: 1}, {a: 1, b: 2});
-
-deltaByteLength(uint8Dictionary, {a: 0}, {b: 0});
-deltaByteLength(uint8Dictionary, {a: 0, b: 0}, {c: 0, d: 0});
-
+const d0 = {};
 const d1 = {a: 0, b: 0, c: 0};
-const d2 = {d: 1, e: 2, f: 3};
+const d2 = {pool: 0, preface: 1, prefix: 2, prefixed: 3};
 
-diffPatchDuration(uint8Dictionary, d1, d1, 1);
-diffPatchDuration(uint8Dictionary, d1, d1, 10);
-diffPatchDuration(uint8Dictionary, d1, d1, 100);
-diffPatchDuration(uint8Dictionary, d1, d1, 1e3);
+diffPatchDuration(dict, d1, d1, 1e3);
 
-diffPatchDuration(uint8Dictionary, d1, d2, 10);
-diffPatchDuration(uint8Dictionary, d1, d2, 100);
-diffPatchDuration(uint8Dictionary, d1, d2, 1e3);
-diffPatchDuration(uint8Dictionary, d1, d2, 1e4);
-diffPatchDuration(uint8Dictionary, d1, d2, 1e5);
+diffPatchDuration(dict, d0, d1, 1e3);
+diffPatchDuration(dict, d0, d1, 1e4);
+diffPatchDuration(dict, d0, d1, 1e5);
+
+diffPatchDuration(dict, d0, d2, 1e3);
+diffPatchDuration(dict, d0, d2, 1e4);
+diffPatchDuration(dict, d0, d2, 1e5);

--- a/src/schema/bench/struct.ts
+++ b/src/schema/bench/struct.ts
@@ -1,27 +1,44 @@
-import { MuStruct, MuUint8 } from '../';
+import { MuStruct, MuUint8, MuVarint, MuRelativeVarint } from '../';
 import { deltaByteLength, diffPatchDuration } from './_do';
 
+{
 const struct = new MuStruct({
     a: new MuUint8(),
     b: new MuUint8(),
-    c: new MuUint8(),
 });
 
-deltaByteLength(struct, {a: 0, b: 0, c: 0}, {a: 0, b: 0, c: 0});
-deltaByteLength(struct, {a: 0, b: 0, c: 0}, {a: 1, b: 0, c: 0});
-deltaByteLength(struct, {a: 0, b: 0, c: 0}, {a: 1, b: 1, c: 0});
-deltaByteLength(struct, {a: 0, b: 0, c: 0}, {a: 1, b: 1, c: 1});
+deltaByteLength(struct, {a: 0, b: 0}, {a:1, b: 0});
+deltaByteLength(struct, {a: 0, b: 0}, {a:1, b: 2});
 
-const s1 = {a: 0, b: 0, c: 0};
-const s2 = {a: 1, b: 2, c: 3};
+const s1 = {a: 0, b: 0};
+const s2 = {a: 1, b: 2};
 
-diffPatchDuration(struct, s1, s1, 1);
-diffPatchDuration(struct, s1, s1, 10);
-diffPatchDuration(struct, s1, s1, 100);
 diffPatchDuration(struct, s1, s1, 1e3);
-
-diffPatchDuration(struct, s1, s2, 10);
-diffPatchDuration(struct, s1, s2, 100);
 diffPatchDuration(struct, s1, s2, 1e3);
 diffPatchDuration(struct, s1, s2, 1e4);
 diffPatchDuration(struct, s1, s2, 1e5);
+}
+
+{
+const struct = new MuStruct({
+    v: new MuVarint(),
+    rv: new MuRelativeVarint(),
+});
+
+deltaByteLength(struct, {v: 0, rv: 0}, {v: 0x7f, rv: 0});
+deltaByteLength(struct, {v: 0, rv: 0}, {v: 0x80, rv: 0});
+deltaByteLength(struct, {v: 0, rv: 0}, {v: 0x80, rv: -0x2a});
+deltaByteLength(struct, {v: 0, rv: 0}, {v: 0x80, rv: -0x2b});
+
+const s1 = {v: 0, rv: 0};
+const s2 = {v: 0x7f, rv: -0x2a};
+const s3 = {v: 0x80, rv: -0x2b};
+
+diffPatchDuration(struct, s1, s1, 1e3);
+diffPatchDuration(struct, s1, s2, 1e3);
+diffPatchDuration(struct, s1, s2, 1e4);
+diffPatchDuration(struct, s1, s2, 1e5);
+diffPatchDuration(struct, s1, s3, 1e3);
+diffPatchDuration(struct, s1, s3, 1e4);
+diffPatchDuration(struct, s1, s3, 1e5);
+}

--- a/src/schema/date.ts
+++ b/src/schema/date.ts
@@ -42,20 +42,22 @@ export class MuDate implements MuSchema<Date> {
     }
 
     public diff (base:Date, target:Date, out:MuWriteStream) : boolean {
-        const bTime = base.getTime();
-        const tTime = target.getTime();
-        if (bTime === tTime) {
-            return false;
+        const bt = base.getTime();
+        const tt = target.getTime();
+        if (bt !== tt) {
+            out.grow(10);
+            out.writeVarint(tt % 0x10000000);
+            out.writeVarint(tt / 0x10000000 | 0);
+            return true;
         }
-
-        out.grow(32);
-        out.writeASCII(target.toISOString());
-        return true;
+        return false;
     }
 
     public patch (base:Date, inp:MuReadStream) : Date {
         const date = this.alloc();
-        date.setTime(Date.parse(inp.readASCII(24)));
+        const lo = inp.readVarint();
+        const hi = inp.readVarint();
+        date.setTime(lo + 0x10000000 * hi);
         return date;
     }
 

--- a/src/schema/rvarint.ts
+++ b/src/schema/rvarint.ts
@@ -9,18 +9,16 @@ export class MuRelativeVarint extends MuNumber<'rvarint'> {
     }
 
     public diff (base:number, target:number, out:MuWriteStream) : boolean {
-        const d = target - base;
-        if (d) {
+        if (base !== target) {
             out.grow(5);
-            out.writeVarint(SCHROEPPEL2 + d ^ SCHROEPPEL2);
+            out.writeVarint((SCHROEPPEL2 + (target - base)) ^ SCHROEPPEL2);
             return true;
         }
         return false;
     }
 
     public patch (base:number, inp:MuReadStream) : number {
-        const x = inp.readVarint();
-        const d = (SCHROEPPEL2 ^ x) - SCHROEPPEL2 >> 0;
-        return base + d >>> 0;
+        const delta = (SCHROEPPEL2 ^ inp.readVarint()) - SCHROEPPEL2 >> 0;
+        return base + delta;
     }
 }

--- a/src/schema/test/serialization.ts
+++ b/src/schema/test/serialization.ts
@@ -37,7 +37,9 @@ import {
     randFloat32,
     randArray,
     randDict,
+    randInt,
     randUint8,
+    randUint32,
 } from '../util/random';
 
 function createTest<T> (
@@ -369,6 +371,8 @@ tape('de/serializing struct', (t) => {
         b: new MuBoolean(),
         u: new MuUTF8(),
         f: new MuFloat32(),
+        i: new MuVarint(),
+        r: new MuRelativeVarint(),
         a: new MuArray(new MuFloat32(), Infinity),
         sa: new MuSortedArray(new MuFloat32(), Infinity),
         v: new MuVector(new MuFloat32(), 9),
@@ -391,6 +395,8 @@ tape('de/serializing struct', (t) => {
         s.b = randBool();
         s.u = strings[Math.random() * 3 | 0];
         s.f = randFloat32();
+        s.i = randUint32();
+        s.r = randInt(-0x40000000, 0x3fffffff),
         s.a = randArray();
         s.sa = randArray().sort(compare);
         s.v = randVec(9);

--- a/src/schema/test/serialization.ts
+++ b/src/schema/test/serialization.ts
@@ -176,7 +176,7 @@ tape('de/serializing varint', (t) => {
         const x = sample[i];
         sample.push(x - 1);
         sample.push(x + 1);
-        sample.push((x + x * Math.random() | 0) >>> 0);
+        sample.push(x + (x * Math.random() | 0) >>> 0);
     }
     sample.push(0xffffffff);
 
@@ -187,13 +187,32 @@ tape('de/serializing varint', (t) => {
         testVarint(x, x);
     }
 
+    t.end();
+});
+
+tape('de/serializing rvarint', (t) => {
+    const sample:number[] = [];
+    for (let i = 0; i < 30; ++i) {
+        sample.push(1 << i);
+        sample.push(-1 << i);
+    }
+    for (let i = sample.length - 1; i >= 0; --i) {
+        const x = sample[i];
+        sample.push(x - 1);
+        sample.push(x + 1);
+        sample.push(x + (x * Math.random() | 0) >> 0);
+    }
+    sample.push(1 << 31);
+
     const testRelativeVarint = createTest(t, new MuRelativeVarint());
     for (let i = 0; i < sample.length; ++i) {
         const x = sample[i];
         testRelativeVarint(0, x);
-        testRelativeVarint(x, 0);
         testRelativeVarint(x, x);
     }
+    testRelativeVarint(0x80000000, 0);
+    testRelativeVarint(0x80000001, 1);
+    testRelativeVarint(0x100000000, 0x80000000);
 
     t.end();
 });

--- a/src/schema/util/random.ts
+++ b/src/schema/util/random.ts
@@ -31,7 +31,7 @@ export function randUint16 () {
 }
 
 export function randUint32 () {
-    return randInt(0, 0xFFFFFFFF);
+    return randInt(0, 0xFFFFFFFF) >>> 0;
 }
 
 // float

--- a/src/stream/index.ts
+++ b/src/stream/index.ts
@@ -140,19 +140,19 @@ export class MuWriteStream {
         const bytes = this.buffer.uint8;
         const offset = this.offset;
 
-        if (x_ < 1 << 7) {
+        if (x_ < 0x80) {
             bytes[offset] = x_;
             this.offset += 1;
-        } else if (x_ < 1 << 14) {
+        } else if (x_ < 0x4000) {
             bytes[offset] = x_ & 0x7f | 0x80;
             bytes[offset + 1] = x_ >>> 7;
             this.offset += 2;
-        } else if (x_ < 1 << 21) {
+        } else if (x_ < 0x200000) {
             bytes[offset] = x_ & 0x7f | 0x80;
             bytes[offset + 1] = x_ >> 7 & 0x7f | 0x80;
             bytes[offset + 2] = x_ >>> 14;
             this.offset += 3;
-        } else if (x_ < 1 << 28) {
+        } else if (x_ < 0x10000000) {
             bytes[offset] = x_ & 0x7f | 0x80;
             bytes[offset + 1] = x_ >> 7 & 0x7f | 0x80;
             bytes[offset + 2] = x_ >> 14 & 0x7f | 0x80;


### PR DESCRIPTION
closes #171 
closes #172 
closes #202 

per diff
* MuArray: reduce up to 3 bytes
* MuASCII: reduce up to 3 bytes
* MuDate: reduce up to 18 bytes