### PR TITLE
Rotate sockets to prevent constantly sending on same socket

### DIFF
--- a/src/socket/web/client.ts
+++ b/src/socket/web/client.ts
@@ -178,18 +178,24 @@ export class MuWebSocket implements MuSocket {
             if (sockets.length > 0) {
                 let socket = sockets[0];
                 let bufferedAmount = socket.bufferedAmount || 0;
+                let idx = 0;
                 for (let i = 1; i < sockets.length; ++i) {
                     const s = sockets[i];
                     const b = s.bufferedAmount || 0;
                     if (b < bufferedAmount) {
                         socket = s;
                         bufferedAmount = b;
+                        idx = i;
                     }
                 }
                 // if buffered amount below cutoff, send a packet
                 // otherwise just drop it
                 if (bufferedAmount < this.bufferLimit) {
                     socket.send(data);
+
+                    // move socket to back of queue
+                    sockets.splice(idx, 1);
+                    sockets.push(socket);
                 }
             }
         } else if (this._reliableSocket) {

--- a/src/socket/web/server.ts
+++ b/src/socket/web/server.ts
@@ -176,17 +176,24 @@ export class MuWebSocketConnection {
                 // find socket with least buffered data
                 let socket = sockets[0];
                 let bufferedAmount = socket.bufferedAmount || 0;
+                let idx = 0;
                 for (let i = 1; i < sockets.length; ++i) {
                     const s = sockets[i];
                     const b = s.bufferedAmount || 0;
                     if (b < bufferedAmount) {
                         socket = s;
                         bufferedAmount = b;
+                        idx = i;
                     }
                 }
                 // only send packet if socket is not blocked
                 if (bufferedAmount < this.bufferLimit) {
+                    // send data
                     socket.send(data);
+
+                    // move socket to back of queue
+                    sockets.splice(idx, 1);
+                    sockets.push(socket);
                 }
             }
         } else {


### PR DESCRIPTION
This should improve latency and reduce head-of-line blocking somewhat.

Sockets are now rotated by buffered amount and time of last use, which should increase the send rate a bit.