### PR TITLE
Annoying bug in local socket

### DIFF
--- a/src/socket/local/index.ts
+++ b/src/socket/local/index.ts
@@ -88,12 +88,13 @@ export class MuLocalSocket implements MuSocket {
                     this._server._handleConnection(this._duplex);
                 }
 
+                spec.ready();
+
+                // drain messages *after* ready handler
                 this._drain();
                 while (this._pendingUnreliableMessages.length) {
                     this._drainUnreliable();
                 }
-
-                spec.ready();
             },
             0);
     }


### PR DESCRIPTION
This fixes a major bug in the local socket where messages were drained before the ready handler was called.  This caused some messages to get dropped and resulted in connection errors.